### PR TITLE
chore: remove banner artifact types

### DIFF
--- a/docs/reference/operator/contract.mdx
+++ b/docs/reference/operator/contract.mdx
@@ -45,10 +45,6 @@ A full example of a Workflow Contract looks like
 
 ## Material Schema
 
-:::tip
-You can expect in the future additional artifact types such as `SPDX_JSON` for sBOM or `SARIF` files for Static Analysis. For now, treat them as regular `ARTIFACT` types.
-:::
-
 | Name       | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`     | yes      |         | unique identifier of the artifact                                                                                                                                                                                                                                                                                                                                                                                                                       |


### PR DESCRIPTION
The banner is no longer needed since we already support SBOM artifact formats.