### PR TITLE
chore: update CI example

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
           chainloop attestation reset --trigger cancellation
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CL_VERSION: 0.8.49
+      CL_VERSION: 0.8.57
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/getting-started/attestation-crafting.md
+++ b/docs/getting-started/attestation-crafting.md
@@ -230,7 +230,7 @@ jobs:
     env:
       # highlight-start
       # Version of Chainloop to install
-      CL_VERSION: 0.8.49
+      CL_VERSION: 0.8.57
       # Export robot-account env variable
       # Used by the CLI to authenticate with the control plane
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,10 +7,9 @@ title: CLI Download
 Chainloop's control plane runs as Software as a Service (SaaS) but we are **committed to making it open source so you can run your own instance**. Stay tuned!
 :::
 
-First, you need to have the Chainloop CLI installed on your computer. Use the command below to **download the latest version**.
+First, you need to have the Chainloop CLI installed on your computer. Use the command below to **download the latest version** and check its integrity.
 
 ```bash
-# Download the binary and check integrity checksum
 curl -sfL https://chainloop.dev/install.sh | bash -s
 ```
 


### PR DESCRIPTION
Chainloop CLI now supports referencing the signing key with an env variable