### PR TITLE
chore: update installation docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Install Chainloop
         run: |
           curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v${{ env.CL_VERSION }}
-          sudo install chainloop /usr/local/bin
-          chainloop version
       - name: Write Cosign key
         run: echo "$COSIGN_KEY" > /tmp/cosign.key
         env:
@@ -54,7 +52,7 @@ jobs:
           chainloop attestation reset --trigger cancellation
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CL_VERSION: 0.8.57
+      CL_VERSION: 0.8.70
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,15 +13,15 @@ If you have any questions, concerns or comments feel free to [reach out](https:/
 
 Chainloop is comprised of two main components
 
-- A Control Plane that runs as a **free open beta** Software as a Service (SaaS)
+- A Control Plane that runs as a **free, open beta** Software as a Service (SaaS)
 - A Command Line Interface (CLI) used to both a) operate on the control plane and b) run the attestation process on your CI/CD
 
 <Image img={require("./chainloop-parts.png")} className="light-mode-only" />
 <Image img={require("./chainloop-parts-dark.png")} className="dark-mode-only" />
 
-## Command Line Interface (CLI) download
+## Command Line Interface (CLI) installation
 
-To **download the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just run
+To **install the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just run
 
 ```bash
 curl -sfL https://chainloop.dev/install.sh | bash -s
@@ -31,6 +31,12 @@ you can retrieve a specific version with
 
 ```bash
 curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v0.1.2
+```
+
+and customize the install path (default to /usr/local/bin)
+
+```bash
+curl -sfL https://chainloop.dev/install.sh | bash -s -- --path /my-path
 ```
 
 if [`cosign`](https://docs.sigstore.dev/cosign) is present in your system, in addition to the checksum check, a signature verification will be performed. This behavior can be enforced via the `--force-verification` flag.
@@ -44,5 +50,5 @@ curl -sfL https://chainloop.dev/install.sh | bash -s -- --force-verification
 Authenticate to the Control Plane with Single Sign-on
 
 ```bash
-$ ./chainloop auth login
+$ chainloop auth login
 ```


### PR DESCRIPTION
The installation script now places the binary in a binary path location. This update the docs to reflect such behavior. 