### PR TITLE
docs: add references to Chainloop Open Source

### DIFF
--- a/blog/2022-12-12-update/index.mdx
+++ b/blog/2022-12-12-update/index.mdx
@@ -54,6 +54,10 @@ By integrating your CI/CD systems with Chainloop you get SLSA provenance level 3
 
 We are committed to making Chainloop Open source, we are figuring out the details. Stay tuned!
 
+Chainloop is now Open Source! 🎉
+
+https://github.com/chainloop-dev/chainloop
+
 ### I am using neither GitHub Actions nor Gitlab, can I still use Chainloop?
 
 Yes, **Chainloop is runner agnostic**, the Workflow Contract can define [the materials, environment variables](/reference/operator/contract#contract-schema) you want your attestation to have.

--- a/docs/chainloop-cloud.md
+++ b/docs/chainloop-cloud.md
@@ -1,0 +1,23 @@
+# Chainloop Cloud
+
+:::caution
+Chainloop is under active development, please don't use it as part of your critical infrastructure until it reaches the 1.0 release.
+:::
+
+Chainloop Cloud is a **free, public beta, Software as a Service instance of [Chainloop Core](https://github.com/chainloop-dev/chainloop)**. It's available to whoever wants to give Chainloop a try without the effort of [deploying their own instance](https://github.com/chainloop-dev/chainloop).
+
+The Chainloop **Command Line Interface (CLI) comes pre-configured to use the Chainloop cloud control plane**.
+
+```sh
+$ chainloop config view
+control-plane: api.cp.chainloop.dev:443
+artifact-cas: api.cas.chainloop.dev:443
+```
+
+But you can easily configure the CLI to point to your own Chainloop instance by using the `config save` command.
+
+```sh
+chainloop config save --control-plane my-controlplane.acme.com --artifact-cas cas.acme.com
+```
+
+If you prefer to run your own instance, you can find the instructions to do so in the [project repository](https://github.com/chainloop-dev/chainloop).

--- a/docs/changelog/changelog.mdx
+++ b/docs/changelog/changelog.mdx
@@ -8,13 +8,14 @@ import Image from "@theme/IdealImage";
 
 Chainloop is composed of multiple code bases, this changelog offers a summarized, non-exhaustive, view of any notable, user-facing change. For more information, refer to each project's GitHub repositories.
 
-- This documentation site source code can be found [here](https://github.com/chainloop-dev/docs).
-- The backend control-plane, CLI and artifact storage proxy have not been open-sourced yet. Stay tuned.
+- This documentation site [source code](https://github.com/chainloop-dev/docs).
+- Chainloop core [source code](https://github.com/chainloop-dev/chainloop/).
 
-## Unreleased
+## v0.8.93 - 2023-03-08
 
-- Fully functional [frontend web UI](https://app.chainloop.dev).
-- Open source components
+Chainloop is now Open Source! 🎉
+
+https://github.com/chainloop-dev/chainloop
 
 ## v0.8.89 - 2023-03-05
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,16 +4,24 @@ sidebar_position: 6
 
 # Frequently Asked Questions
 
-### I am using neither GitHub Actions nor GitLab, can I still use Chainloop?
+#### Is Chainloop Open Source?
+
+Yes, Chainloop source code has been Open Sourced and can be found [here](https://github.com/chainloop-dev/chainloop)! 🎉
+
+#### Can I run my own instance of Chainloop end to end?
+
+Yes, please refer to the deployment instructions that can be found in [this repository](https://github.com/chainloop-dev/chainloop)
+
+#### In this documentation site there are references to Chainloop Cloud, what is it?
+
+Chainloop cloud is an available, running instance of Chainloop. For more information refer to the [Chainloop Cloud page](./chainloop-cloud).
+
+#### I am using neither GitHub Actions nor GitLab, can I still use Chainloop?
 
 Yes, Chainloop is runner agnostic, which means that you can run the attestation anywhere, including your laptop!
 
 That said, there are [benefits](/reference/operator/contract#runner-context) for using one of our [supported runner types](/reference/operator/contract#runner-context). We plan on supporting more CI vendors so your is not supported yet, please [contact us](https://us21.list-manage.com/contact-form?u=801f42b3abafc40b1a17c5f25&form_id=3f3bbfe15e6fcd4a60be9b966652cfd5) with your preference and we will get back to you.
 
-### Will Chainloop be Open Source?
-
-Yes, we are committed to making Chainloop Open source. We are working out the details. Stay tuned!
-
-### Does Chainloop store my Artifacts and Attestation
+#### Does Chainloop store my Artifacts and Attestation metadata?
 
 No. They are stored in [your OCI Registry](/getting-started/setup#add-oci-repository).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,16 +4,12 @@ title: Installation
 ---
 
 import Image from "@theme/IdealImage";
-
-:::info
-Chainloop's control plane runs as Software as a Service (SaaS) but we are **committed to making it open source so you can run your own instance**.
-
-If you have any questions, concerns or comments feel free to [reach out](https://us21.list-manage.com/contact-form?u=801f42b3abafc40b1a17c5f25&form_id=3f3bbfe15e6fcd4a60be9b966652cfd5)
-:::
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 Chainloop is comprised of two main components
 
-- A Control Plane that runs as a **free, open beta** Software as a Service (SaaS)
+- A Control Plane that acts as single source of truth and management console.
 - A Command Line Interface (CLI) used to both a) operate on the control plane and b) run the attestation process on your CI/CD
 
 <Image img={require("./chainloop-parts.png")} className="light-mode-only" />
@@ -21,7 +17,10 @@ Chainloop is comprised of two main components
 
 ## Command Line Interface (CLI) installation
 
-To **install the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just run
+To **install the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just choose one of the following installation method.
+
+<Tabs>
+  <TabItem value="script" label="Installation Script" default>
 
 ```bash
 curl -sfL https://docs.chainloop.dev/install.sh | bash -s
@@ -45,10 +44,45 @@ if [`cosign`](https://docs.sigstore.dev/cosign) is present in your system, in ad
 curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --force-verification
 ```
 
+</TabItem>
+<TabItem value="github" label="GitHub Release">
+
+Refer to GitHub [releases page](https://github.com/chainloop-dev/chainloop/releases) and download the binary of your choice.
+
+</TabItem>
+<TabItem value="source" label="From Source">
+
+```sh
+git clone git@github.com:chainloop-dev/chainloop
+cd chainloop && make -C app/cli build
+
+./app/cli/bin/chainloop version
+=> chainloop version v0.8.93-3-ged05b96
+```
+
+</TabItem>
+</Tabs>
+
+## Configure CLI (optional)
+
+By default, Chainloop CLI points to a [running Software as a Service (SaaS) instance of Chainloop](../chainloop-cloud).
+
+If you are running your [own instance](https://github.com/chainloop-dev/chainloop) of Chainloop Control Plane. You can make the CLI point to your instance by using the `chainloop config save` command.
+
+```sh
+chainloop config save \
+  --control-plane my-controlplane.acme.com \
+  --artifact-cas cas.acme.com
+```
+
 ## Authentication
 
-Authenticate to the Control Plane with Single Sign-on
+Authenticate to the Control Plane by running
 
 ```bash
 $ chainloop auth login
 ```
+
+That's all!
+
+Welcome to Chainloop!

--- a/docs/how-does-it-work/how-does-it-work.mdx
+++ b/docs/how-does-it-work/how-does-it-work.mdx
@@ -8,7 +8,7 @@ import Image from "@theme/IdealImage";
 
 # How Does it Work?
 
-Chainloop is a Software as a Service (Open Source soon), that consists of a [SLSA level 3](https://slsa.dev/spec/v0.1/requirements#summary-table) provenance-compliant **control plane and single source of truth** for artifacts and attestation **plus a dead-simple, [contract-based](/getting-started/workflow-definition#workflow-contracts) attestation crafting process**.
+Chainloop is an [Open Source](https://github.com/chainloop-dev/chainloop) [SLSA level 3](https://slsa.dev/spec/v0.1/requirements#summary-table) provenance-compliant **control plane and single source of truth** for artifacts and attestation **plus a dead-simple, [contract-based](/getting-started/workflow-definition#workflow-contracts) attestation crafting process**.
 
 In practice, that means a solution that provides
 


### PR DESCRIPTION
Update documentation to indicate the new Open Source nature of the project https://github.com/chainloop-dev/chainloop