### PR TITLE
docs(integrations): add guac integration to index

### DIFF
--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -19,6 +19,7 @@ Below you can find the list of currently available integrations. If you can't fi
 | [smtp](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/smtp/v1/README.md) | 1.0 | Send emails with information about a received attestation |  |
 | [oci-registry](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/oci-registry/v1/README.md) | 1.0 | Send attestations to a compatible OCI registry |  |
 | [discord-webhook](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/discord-webhook/v1/README.md) | 1.1 | Send attestations to Discord |  |
+| [guac](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/guac/v1/README.md) | 1.0 | Export Attestation and SBOMs metadata to a blob storage backend so guacsec/guac can consume it | SBOM_CYCLONEDX_JSON, SBOM_SPDX_JSON |
 
 ## How to use integrations
 


### PR DESCRIPTION
Result of running

```
yarn run docusaurus download-remote-integrations-index
```

Refs https://github.com/chainloop-dev/chainloop/issues/209
