### PR TITLE
deployment: update guide

### DIFF
--- a/docs/guides/deployment/deployment.mdx
+++ b/docs/guides/deployment/deployment.mdx
@@ -2,27 +2,32 @@
 title: Deploy on Kubernetes
 image: ./deployment.png
 ---
-
 import Image from "@theme/IdealImage";
 
-We've built a [Helm Chart](https://github.com/chainloop-dev/chainloop/tree/main/deployment/chainloop) that can be used to deploy a [Chainloop](https://github.com/chainloop-dev/chainloop) instance on your [Kubernetes](https://kubernetes.io) cluster.
+# Chainloop Helm Chart
 
-Some of the pre-requisites are:
+[Chainloop](https://github.com/chainloop-dev/chainloop) is an open-source software supply chain control plane, a single source of truth for artifacts plus a declarative attestation crafting process.
+
+## Introduction
+
+This chart bootstraps a [Chainloop](https://github.com/chainloop-dev/chainloop) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
 
 - Kubernetes 1.19+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure (If built-in PostgreSQL is enabled)
 
-Compatibility with the following Ingress Controllers have been verified, other controllers might or might not work.
+Compatibility with the following Ingress Controllers has been verified, other controllers might or might not work.
 
 - [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
 - [Traefik](https://doc.traefik.io/traefik/providers/kubernetes-ingress/)
 
 ## TL;DR
 
-Deploy Chainloop in **[development mode](#development)** by running
+Deploy Chainloop in [development mode](#development) by running
 
-```bash
+```console
 helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     --set development=true \
     --set controlplane.auth.oidc.url=[OIDC URL] \
@@ -38,32 +43,31 @@ This chart comes in **two flavors**, `standard` and [`development`](#development
 
 ### Standard (default)
 
-<Image img={require("./deployment.png")} className="light-mode-only" />
-<Image img={require("./deployment-dark.png")} className="dark-mode-only" />
+<Image img={require("./deployment.png")} className="light-mode-only" /> <Image img={require("./deployment-dark.png")} className="dark-mode-only" />
 
 The default deployment mode relies on external dependencies to be available in advance.
 
 The Helm Chart in this mode includes
 
-- Chainloop [Controlplane](https://github.com/chainloop-dev/chainloop/tree/main/app/controlplane) 
-- Chainloop [Artifact proxy](https://github.com/chainloop-dev/chainloop/tree/main/app/artifact-cas) 
+- Chainloop [Controlplane](https://github.com/chainloop-dev/chainloop/tree/main/app/controlplane)
+- Chainloop [Artifact proxy](https://github.com/chainloop-dev/chainloop/tree/main/app/artifact-cas)
 - A PostgreSQL dependency enabled by default
 
 During installation, you'll need to provide
 
 - Open ID Connect Identity Provider (IDp) settings i.e [Auth0 settings](https://auth0.com/docs/get-started/applications/application-settings#basic-information)
 - Connection settings for a secrets storage backend, either [Hashicorp Vault](https://www.vaultproject.io/) or [AWS Secret Manager](https://aws.amazon.com/secrets-manager)
-- ECDSA (ES512) key-pair used for Controlplane <-> CAS Authentication. 
+- ECDSA (ES512) key-pair used for Controlplane <-> CAS Authentication
 
 Instructions on how to create the ECDSA keypair can be found [here](#generate-a-ecdsa-key-pair).
 
 #### Installation Examples
 
-> **NOTE**: **We do not recommend passing nor storing sensitive data in plain text**. For production, please consider having your overrides encrypted with tools such as [sops](https://github.com/mozilla/sops), [Helm Secrets](https://github.com/jkroepke/helm-secrets) or [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) 
+> **NOTE**: **We do not recommend passing nor storing sensitive data in plain text**. For production, please consider having your overrides encrypted with tools such as [Sops](https://github.com/mozilla/sops), [Helm Secrets](https://github.com/jkroepke/helm-secrets) or [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets).
 
 Deploy Chainloop configured to talk to the bundled PostgreSQL an external OIDC IDp and a Vault instance.
 
-```bash
+```console
 helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     # Open ID Connect (OIDC)
     --set controlplane.auth.oidc.url=[OIDC URL] \
@@ -79,11 +83,12 @@ helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
 
 Deploy using AWS secret manager instead of Vault
 
-```bash
+```console
 helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     # Open ID Connect (OIDC)
     # ...
     # Secrets backend
+    --set secretsBackend.backend=awsSecretManager \
     --set secretsBackend.awsSecretManager.accessKey=[AWS ACCESS KEY ID] \
     --set secretsBackend.awsSecretManager.secretKey=[AWS SECRET KEY] \
     --set secretsBackend.awsSecretManager.region=[AWS region]\
@@ -91,9 +96,23 @@ helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     # ...
 ```
 
+Deploy using GCP secret manager instead of Vault
+
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
+    # Open ID Connect (OIDC)
+    # ...
+    # Secrets backend
+    --set secretsBackend.backend=gcpSecretManager \
+    --set secretsBackend.gcpSecretManager.projectId=[GCP Project ID] \
+    --set secretsBackend.gcpSecretManager.authKey=[GCP Auth KEY] \
+    # Server Auth KeyPair
+    # ...
+```
+
 Connect to an external PostgreSQL database instead
 
-```bash
+```console
 helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     # Open ID Connect (OIDC)
     # ...
@@ -113,13 +132,14 @@ helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
 
 To provide an easy way to give Chainloop a try, this Helm Chart has an **opt-in development** mode that can be enabled with the flag `development=true`
 
-<Image img={require("./deployment-dev.png")} className="light-mode-only" />
-<Image img={require("./deployment-dev-dark.png")} className="dark-mode-only" />
+> IMPORTANT: DO NOT USE THIS MODE IN PRODUCTION
+
+<Image img={require("./deployment-dev.png")} className="light-mode-only" /> <Image img={require("./deployment-dev-dark.png")} className="dark-mode-only" />
 
 The Helm Chart in this mode includes
 
-- Chainloop [Controlplane](https://github.com/chainloop-dev/chainloop/tree/main/app/controlplane) 
-- Chainloop [Artifact proxy](https://github.com/chainloop-dev/chainloop/tree/main/app/artifact-cas) 
+- Chainloop [Controlplane](https://github.com/chainloop-dev/chainloop/tree/main/app/controlplane)
+- Chainloop [Artifact proxy](https://github.com/chainloop-dev/chainloop/tree/main/app/artifact-cas)
 - A PostgreSQL dependency enabled by default
 - **A pre-configured Hashicorp Vault instance running in development mode (unsealed, in-memory, insecure)**
 
@@ -135,19 +155,18 @@ During installation, you'll need to provide
 
 Deploy by leveraging built-in Vault and PostgreSQL instances
 
-```bash
+```console
 helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     --set development=true \
     --set controlplane.auth.oidc.url=[OIDC URL] \
     --set controlplane.auth.oidc.clientID=[clientID] \
     --set controlplane.auth.oidc.clientSecret=[clientSecret]
 ```
-
 ## How to guides
 
 ### Generate a ECDSA key-pair
 
-A ECDSA key-pair is required to perform authentication between the control-plane and the Artifact CAS
+An ECDSA key-pair is required to perform authentication between the control-plane and the Artifact CAS
 
 You can generate both the private and public keys by running
 
@@ -158,7 +177,7 @@ openssl ecparam -name secp521r1 -genkey -noout -out private.ec.key
 openssl ec -in private.ec.key -pubout -out public.pem
 ```
 
-Then, you can either provide it in a custom values.yaml file override
+Then, you can either provide it in a custom `values.yaml` file override
 
 ```yaml
 casJWTPrivateKey: |-
@@ -171,7 +190,7 @@ casJWTPublicKey: |
     -----END PUBLIC KEY-----
 ```
 
-or as shown before, provide them as imperative inputs during Helm Install/Upgrade `--set casJWTPrivateKey="$(cat private.ec.key)"--set casJWTPublicKey="$(cat public.pem)"` 
+or as shown before, provide them as imperative inputs during Helm Install/Upgrade `--set casJWTPrivateKey="$(cat private.ec.key)"--set casJWTPublicKey="$(cat public.pem)"`
 
 ### Enable a custom domain with TLS
 
@@ -188,9 +207,9 @@ controlplane:
   ingressAPI:
     enabled: true
     hostname: api.cp.chainloop.dev
-          
+
 cas:
-  ingressAPI:
+    ingressAPI:
     enabled: true
     hostname: api.cas.chainloop.dev
 ```
@@ -198,7 +217,7 @@ cas:
 A complete setup that uses
 
 - NGINX as ingress Controller https://kubernetes.github.io/ingress-nginx/
-- [cert-manager](https://cert-manager.io/) as tls provider
+- [cert-manager](https://cert-manager.io/) as TLS provider
 
 would look like
 
@@ -235,10 +254,10 @@ cas:
       # 0 means to not check the size of the request so we do not get 413 error.
       # For now we are going to set a limit on 100MB files
       # Even though we send data in chunks of 1MB, this size refers to all the data sent in the streaming connection
-      nginx.ingress.kubernetes.io/proxy-body-size: "100m"          
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 ```
 
-Remember, once you have set up your domain, make sure you use the [CLI pointing](#configure-chainloop-cli-to-point-to-new-instance) to it instead of the defaults.
+Remember, once you have set up your domain, make sure you use the [CLI pointing](#configure-chainloop-cli-to-point-to-your-instance) to it instead of the defaults.
 
 ### Connect to an external PostgreSQL database
 
@@ -269,9 +288,9 @@ postgresql:
 # Provide with external connection
 controlplane:
     sqlProxy:
-        # Inject the proxy sidecar 
+        # Inject the proxy sidecar
         enabled: true
-        ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name 
+        ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name
         connectionName: "my-sql-instance"
     # Then you'll need to configure your DB settings to use the proxy IP address
     externalDatabase:
@@ -294,6 +313,19 @@ secretsBackend:
         secretKey: [SECRET]
         region: [REGION]
 ```
+
+### Use GCP secret manager
+
+You can swap the secret manager backend with the following settings
+
+```yaml
+secretsBackend:
+    backend: gcpSecretManager
+    gcpSecretManager:
+        projectId: [PROJECT_ID]
+        authKey: [KEY]
+```
+
 ### Send exceptions to Sentry
 
 ```yaml
@@ -307,11 +339,11 @@ sentry:
 
 Chainloop exposes Prometheus compatible `/metrics` endpoints that can be easily scraped by a Prometheus data collector Server.
 
-Google Cloud has a [managed prometheus offering](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed) that could be easily enabled by setting `--set GKEMonitoring.enabled=true`. This will inject the required `PodMonitoring` custom resources.
+Google Cloud has a [managed Prometheus offering](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed) that could be easily enabled by setting `--set GKEMonitoring.enabled=true`. This will inject the required `PodMonitoring` custom resources.
 
-### Configure Chainloop CLI to point to new instance
+### Configure Chainloop CLI to point to your instance
 
-Once you have your instance of Chainloop deployed, you need to configure the [CLI](https://github.com/chainloop-dev/chainloop/releases) to point to both the CAS and the Controlplane gRPC APIs like this.
+Once you have your instance of Chainloop deployed, you need to configure the [CLI](https://github.com/chainloop-dev/chainloop/releases) to point to both the CAS and the Control plane gRPC APIs like this.
 
 ```
 chainloop config save \
@@ -334,15 +366,17 @@ chainloop config save \
 
 ### Secrets Backend
 
-| Name                                        | Description                                                          | Value       |
-| ------------------------------------------- | -------------------------------------------------------------------- | ----------- |
-| `secretsBackend.backend`                    | Secrets backend type ("vault" or "awsSecretManager")                 | `vault`     |
-| `secretsBackend.secretPrefix`               | Prefix that will be pre-pended to all secrets in the storage backend | `chainloop` |
-| `secretsBackend.vault.address`              | Vault address                                                        |             |
-| `secretsBackend.vault.token`                | Vault authentication token                                           |             |
-| `secretsBackend.awsSecretManager.accessKey` | AWS Access KEY ID                                                    |             |
-| `secretsBackend.awsSecretManager.secretKey` | AWS Secret Key                                                       |             |
-| `secretsBackend.awsSecretManager.region`    | AWS Secret Manager Region                                            |             |
+| Name                                        | Description                                                               | Value       |
+| ------------------------------------------- | ------------------------------------------------------------------------- | ----------- |
+| `secretsBackend.backend`                    | Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager")  | `vault`     |
+| `secretsBackend.secretPrefix`               | Prefix that will be pre-pended to all secrets in the storage backend      | `chainloop` |
+| `secretsBackend.vault.address`              | Vault address                                                             |             |
+| `secretsBackend.vault.token`                | Vault authentication token                                                |             |
+| `secretsBackend.awsSecretManager.accessKey` | AWS Access KEY ID                                                         |             |
+| `secretsBackend.awsSecretManager.secretKey` | AWS Secret Key                                                            |             |
+| `secretsBackend.awsSecretManager.region`    | AWS Secret Manager Region                                                 |             |
+| `secretsBackend.gcpSecretManager.projectId` | GCP Project ID                                                            |             |
+| `secretsBackend.gcpSecretManager.authKey`   | GCP Auth Key                                                              |             |
 
 ### Authentication
 
@@ -358,6 +392,7 @@ chainloop config save \
 | `controlplane.replicaCount`     | Number of replicas                                                                  | `2`                                             |
 | `controlplane.image.repository` | FQDN uri for the image                                                              | `ghcr.io/chainloop-dev/chainloop/control-plane` |
 | `controlplane.image.tag`        | Image tag (immutable tags are recommended). If no set chart.appVersion will be used |                                                 |
+| `controlplane.pluginsDir`       | Directory where to look for plugins                                                 | `/plugins`                                      |
 
 ### Control Plane Database
 
@@ -494,6 +529,20 @@ chainloop config save \
 | `vault.server.dev.enabled`           | Enable development mode (unsealed, in-memory, insecure)                                                | `true`         |
 | `vault.server.dev.devRootToken`      | Connection token                                                                                       | `notapassword` |
 
-## Contributing
 
-[Here](https://github.com/chainloop-dev/chainloop/tree/main/deployment/chainloop) you can find the Helm Chart source code. Refer to our [contribution guidelines](https://github.com/chainloop-dev/chainloop/blob/main/CONTRIBUTING.md) for details. 
+## License
+
+Copyright &copy; 2023 The Chainloop Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,6 +103,37 @@ ${content.replaceAll("./img/fanout.png", "/img/fanout.png")}`,
         },
       },
     ],
+    // Helm Chart readme
+    // yarn run docusaurus download-remote-deployment-readme
+    [
+      "docusaurus-plugin-remote-content",
+      {
+        name: "deployment-readme",
+        noRuntimeDownloads: true,
+        performCleanup: false,
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/chainloop-dev/chainloop/main/deployment/chainloop",
+        outDir: "docs/guides/deployment/", // the base directory to output to.
+        documents: ["README.md"], // the file names to download
+        modifyContent: (filename, content) => {
+          if (filename.includes("README")) {
+            return {
+              content: `---
+title: Deploy on Kubernetes
+image: ./deployment.png
+---
+import Image from "@theme/IdealImage";
+
+${content.replaceAll("![Deployment](../../docs/img/deployment.png)", "<Image img={require(\"./deployment.png\")} className=\"light-mode-only\" /> <Image img={require(\"./deployment-dark.png\")} className=\"dark-mode-only\" />") 
+.replaceAll("![Deployment](../../docs/img/deployment-dev.png)", "<Image img={require(\"./deployment-dev.png\")} className=\"light-mode-only\" /> <Image img={require(\"./deployment-dev-dark.png\")} className=\"dark-mode-only\" />")} `,
+              filename: "deployment.mdx"
+            };
+          }
+
+          return undefined;
+        },
+      },
+    ],
   ],
 
   presets: [


### PR DESCRIPTION
- Update docusaurus config to import the Helm Chart readme from the upstream repo instead of manually maintaining a copy. 
- Update the deployment guide with latest changes (gcpSecretmanager and plugins)