### PR TITLE
chore(ci): disable deployment concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+# Limit to a single workflow
+concurrency: "deploy-to-prod"
+
 jobs:
   deploy:
     name: Deploy


### PR DESCRIPTION
I noticed a race condition where an older deployment job finished after the new one, overriding the latest content.

This code limits that behavior by creating a queue in practice. 