### PR TITLE
feat(installer): support aarch64 as alias for arm64

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -119,7 +119,7 @@ case $UNAME_ARC in
 "x86_64")
     ARC="amd64"
     ;;
-"arm64")
+"arm64"|"aarch64")
     ARC="arm64"
     ;;
 *)


### PR DESCRIPTION
Fixes the following issue:
https://github.com/chainloop-dev/chainloop/issues/418

Test from within a Linux docker container hosted by OSX M1:

<img width="1015" alt="image" src="https://github.com/chainloop-dev/docs/assets/11213785/8d6ffc63-34d7-481d-b067-75b916fd7094">
